### PR TITLE
Reduce places where to change Java version

### DIFF
--- a/docker/dockerfiles/java.dockerfile
+++ b/docker/dockerfiles/java.dockerfile
@@ -11,7 +11,7 @@ WORKDIR $APP_DIR
 COPY --chown=starcraft:users jre-8u192-windows-i586.tar.gz jre.tar.gz
 RUN set -x \
     && tar xzf jre.tar.gz\
-    && mv jre1.8.0_192/ $JAVA_DIR/ \
+    && mv jre1.8.0_*/ $JAVA_DIR/ \
     && rm jre.tar.gz
 
 COPY scripts/win_java32 /usr/bin/win_java32


### PR DESCRIPTION
during building docker images
This is probably safer version of #10 . At least now one less place where to worry about Java patch version.  