### PR TITLE
Support overriding the random seed for the game

### DIFF
--- a/docker/bwapi/bot/bwapi.ini
+++ b/docker/bwapi/bot/bwapi.ini
@@ -46,4 +46,5 @@ height = 480
 sound = OFF
 screenshots = gif
 speed_override = 
+seed_override = 
 drop_players = ON

--- a/docker/bwapi/human/bwapi.ini
+++ b/docker/bwapi/human/bwapi.ini
@@ -46,4 +46,5 @@ height = 480
 sound = OFF
 screenshots = gif
 speed_override = 
+seed_override = 
 drop_players = ON

--- a/docker/scripts/play_common.sh
+++ b/docker/scripts/play_common.sh
@@ -54,6 +54,7 @@ function prepare_bwapi() {
     sed -i "s:^save_replay = :save_replay = maps/replays/$REPLAY_FILE:g" "${BWAPI_INI}"
     sed -i "s:^wait_for_min_players = :wait_for_min_players = $NUM_PLAYERS:g" "${BWAPI_INI}"
     sed -i "s:^speed_override = :speed_override = $SPEED_OVERRIDE:g" "${BWAPI_INI}"
+    sed -i "s:^seed_override = :seed_override = $SEED_OVERRIDE:g" "${BWAPI_INI}"
 
     # todo: solve bug with "Unable to distribute map"
     # hotfix for headful mode, but we need to select map unfortunately

--- a/scbw/cli.py
+++ b/scbw/cli.py
@@ -64,6 +64,8 @@ parser.add_argument("--game_type", type=str, metavar="GAME_TYPE",
 parser.add_argument("--game_speed", type=int, default=0,
                     help="Set game speed (pause of ms between frames),\n"
                          "use -1 for game default.")
+parser.add_argument("--seed_override", type=int, default=0,
+                    help="Set random seed.")
 parser.add_argument("--timeout", type=int, default=None,
                     help="Kill docker container after timeout seconds.\n"
                          "If not set, run without timeout.")

--- a/scbw/cli.py
+++ b/scbw/cli.py
@@ -64,7 +64,7 @@ parser.add_argument("--game_type", type=str, metavar="GAME_TYPE",
 parser.add_argument("--game_speed", type=int, default=0,
                     help="Set game speed (pause of ms between frames),\n"
                          "use -1 for game default.")
-parser.add_argument("--seed_override", type=int, default=0,
+parser.add_argument("--seed_override", type=int,
                     help="Set random seed.")
 parser.add_argument("--timeout", type=int, default=None,
                     help="Kill docker container after timeout seconds.\n"

--- a/scbw/docker_utils.py
+++ b/scbw/docker_utils.py
@@ -162,6 +162,7 @@ def launch_image(
         map_name: str,
         game_type: GameType,
         game_speed: int,
+        seed_override: int,
         timeout: Optional[int],
         timeout_at_frame: Optional[int],
         hide_names: bool,
@@ -218,6 +219,7 @@ def launch_image(
         MAP_NAME=f"/app/sc/maps/{map_name}",
         GAME_TYPE=game_type.value,
         SPEED_OVERRIDE=game_speed,
+        SEED_OVERRIDE=seed_override,
         HIDE_NAMES="1" if hide_names else "0",
         DROP_PLAYERS="1" if drop_players else "0",
 
@@ -225,6 +227,7 @@ def launch_image(
         TM_LOG_FRAMETIMES=f"../logs/frames.csv",
         TM_LOG_UNIT_EVENTS=f"../logs/unit_events.csv",
         TM_SPEED_OVERRIDE=game_speed,
+        TM_SEED_OVERRIDE=seed_override,
         TM_ALLOW_USER_INPUT="1" if isinstance(player, HumanPlayer) or allow_input else "0",
         TM_TIME_OUT_AT_FRAME=timeout_at_frame or "-1",
 

--- a/scbw/docker_utils.py
+++ b/scbw/docker_utils.py
@@ -162,7 +162,7 @@ def launch_image(
         map_name: str,
         game_type: GameType,
         game_speed: int,
-        seed_override: int,
+        seed_override: str,
         timeout: Optional[int],
         timeout_at_frame: Optional[int],
         hide_names: bool,

--- a/scbw/game.py
+++ b/scbw/game.py
@@ -103,6 +103,11 @@ def run_game(
     else:
         _wait_callback = wait_callback
 
+    # Seed override is empty string if not specified, integer otherwise
+    seed_override = ""
+    if args.seed_override is not None:
+        seed_override = str(args.seed_override)
+
     # Prepare game launching
     launch_params = dict(
         # game settings
@@ -111,7 +116,7 @@ def run_game(
         map_name=args.map,
         game_type=GameType(args.game_type),
         game_speed=args.game_speed,
-        seed_override=args.seed_override,
+        seed_override=seed_override,
         timeout=args.timeout,
         timeout_at_frame=args.timeout_at_frame,
         hide_names=args.hide_names,

--- a/scbw/game.py
+++ b/scbw/game.py
@@ -32,6 +32,7 @@ class GameArgs(Namespace):
     game_name: str
     game_type: str
     game_speed: int
+    seed_override: int
     hide_names: bool
     random_names: bool
     timeout: int
@@ -110,6 +111,7 @@ def run_game(
         map_name=args.map,
         game_type=GameType(args.game_type),
         game_speed=args.game_speed,
+        seed_override=args.seed_override,
         timeout=args.timeout,
         timeout_at_frame=args.timeout_at_frame,
         hide_names=args.hide_names,


### PR DESCRIPTION
BWAPI has the option to specify the random seed when starting a game. This PR exposes this functionality for games run in sc-docker.

I envision this to be most useful for bot authors, but it could also be useful if for some reason a user wants to generate the random seeds in a different way than StarCraft does.

For bot authors, I see primarily two use cases.

First, it allows a bot author to continuously re-run the same game while making adjustments to their bot. By setting the random seed to a fixed value and not enabling the read_overwrite option, successive games between two bots will be mostly similar, though non-deterministic factors in BWAPI do cause them to diverge as the games progress. This is still very useful in cases where the author is working on a new feature or bugfix and needs a stable environment to test in.

Second, if the bot author keeps track of the random seeds while running a series of games (e.g. by having their sc-docker training script generate the seeds), it allows them to go back and re-run specific games later. Bot behaviour may of course depend on other factors (learning data, etc.), but at least the same start positions are guaranteed.