### PR TITLE
Update registry at build time

### DIFF
--- a/docker/dockerfiles/wine.dockerfile
+++ b/docker/dockerfiles/wine.dockerfile
@@ -1,5 +1,5 @@
 # Basic images to build up X server with wine.
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 LABEL maintainer="Michal Sustr <michal.sustr@aic.fel.cvut.cz>"
 
 ENV APP_DIR /app
@@ -53,13 +53,13 @@ RUN set -x \
   && apt-get install wget gnupg2 software-properties-common -y \
   && dpkg --add-architecture i386 \
   && wget -nc https://dl.winehq.org/wine-builds/winehq.key \
-  && wget -nc https://download.opensuse.org/repositories/Emulators:/Wine:/Debian/xUbuntu_18.04/Release.key \
+  && wget -nc https://download.opensuse.org/repositories/Emulators:/Wine:/Debian/xUbuntu_20.04/Release.key \
   && apt-key add winehq.key \
   && apt-key add Release.key \
   && apt-add-repository 'deb https://dl.winehq.org/wine-builds/ubuntu/ bionic main' \
-  && add-apt-repository 'deb https://download.opensuse.org/repositories/Emulators:/Wine:/Debian/xUbuntu_18.04/ ./' \
+  && add-apt-repository 'deb https://download.opensuse.org/repositories/Emulators:/Wine:/Debian/xUbuntu_20.04/ ./' \
   && apt-get update -y \
-  && apt-get install -y --no-install-recommends xvfb xauth x11vnc winehq-stable winetricks \
+  && apt-get install -y --no-install-recommends xvfb xauth x11vnc winehq-stable winetricks unzip \
   # wine32 winetricks ca-certificates winbind \
   && rm -rf /var/lib/apt/lists/*
 

--- a/docker/scripts/play_bot.sh
+++ b/docker/scripts/play_bot.sh
@@ -40,13 +40,10 @@ if [ "$IS_HEADFUL" == "1" ]; then
     start_gui
 fi
 start_bot
-sleep 1
 
 start_game "$@"
-sleep 3
 
 connect_bot
-sleep 1
 
 if [ "$IS_HEADFUL" == "1" ] && [ $NTH_PLAYER == "0" ] && [ "$HEADFUL_AUTO_LAUNCH" == "1" ]; then # if is_server
     auto_launch

--- a/docker/scripts/play_common.sh
+++ b/docker/scripts/play_common.sh
@@ -169,7 +169,8 @@ function start_game() {
 
     [ -f "$MAP_DIR/replays/LastReplay.rep" ] && rm "$MAP_DIR/replays/LastReplay.rep"
 
-    update_registry
+    # Now done at container build time
+    #update_registry
 
     # Launch the game!
     LOG "Starting game" >> "$LOG_GAME"

--- a/docker/scripts/play_common.sh
+++ b/docker/scripts/play_common.sh
@@ -105,6 +105,8 @@ function connect_bot() {
         if [ "$BOT_TYPE" == "dll" ] && [ -f "$BWAPI_DATA_DIR/AI/run_connect.bat" ]; then
             LOG "Running run_connect.bat for Module bot *AFTER* game has started." >> "$LOG_BOT"
             WINEPATH="$JAVA_DIR/bin" wine cmd /c "$BWAPI_DATA_DIR/AI/run_connect.bat" >> "${LOG_BOT}" 2>&1
+
+            sleep 1
         fi
 
         popd
@@ -156,6 +158,8 @@ function start_bot() {
         popd
     } &
 
+    sleep 1
+
     . hook_after_bot_start.sh
 
 }
@@ -172,6 +176,9 @@ function start_game() {
     echo "------------------------------------------" >> "$LOG_GAME"
 
     launch_game "$@" >> "$LOG_GAME" 2>&1  &
+
+    # Wait up to 30s for game to be started
+    run_with_timeout 30 detect_game_started
 
     . hook_after_game_start.sh
 }
@@ -205,6 +212,19 @@ function check_bot_requirements() {
         LOG "Bot type can be only one of 'jar', 'exe', 'dll', 'jython' but the type supplied is '$BOT_TYPE'"
         exit 1
     fi
+}
+
+function detect_game_started() {
+    while true
+    do
+        if pgrep -x "StarCraft.exe" > /dev/null
+        then
+            LOG "Game started!" >> "$LOG_GAME"
+            return 0
+        fi
+
+        sleep 0.5
+    done;
 }
 
 function detect_game_finished() {

--- a/scbw/local_docker/game.dockerfile
+++ b/scbw/local_docker/game.dockerfile
@@ -28,4 +28,35 @@ VOLUME $BWAPI_DATA_BWTA_DIR $BWAPI_DATA_BWTA2_DIR $MAP_DIR $BOT_DIR $BOT_DATA_WR
 
 RUN echo "umask 0027" >> /home/starcraft/.bashrc
 
+# Update the StarCraft registry keys
+# This was previously done in a script on container startup (see play_common.sh), but it's more efficient to do at build time
+# The sleep at the end is important, as we need to ensure the file is flushed before Docker creates the layer
+RUN wine REG ADD "HKEY_LOCAL_MACHINE\SOFTWARE\Blizzard Entertainment\Starcraft" /v ColorCycle /t REG_DWORD /d 00000001 \
+    && wine REG ADD "HKEY_LOCAL_MACHINE\SOFTWARE\Blizzard Entertainment\Starcraft" /v UnitPortraits /t REG_DWORD /d 00000002 \
+    && wine REG ADD "HKEY_LOCAL_MACHINE\SOFTWARE\Blizzard Entertainment\Starcraft" /v speed /t REG_DWORD /d 00000006 \
+    && wine REG ADD "HKEY_LOCAL_MACHINE\SOFTWARE\Blizzard Entertainment\Starcraft" /v mscroll /t REG_DWORD /d 00000001 \
+    && wine REG ADD "HKEY_LOCAL_MACHINE\SOFTWARE\Blizzard Entertainment\Starcraft" /v kscroll /t REG_DWORD /d 00000001 \
+    && wine REG ADD "HKEY_LOCAL_MACHINE\SOFTWARE\Blizzard Entertainment\Starcraft" /v m_mscroll /t REG_DWORD /d 00000003 \
+    && wine REG ADD "HKEY_LOCAL_MACHINE\SOFTWARE\Blizzard Entertainment\Starcraft" /v m_kscroll /t REG_DWORD /d 00000003 \
+    && wine REG ADD "HKEY_LOCAL_MACHINE\SOFTWARE\Blizzard Entertainment\Starcraft" /v tipnum /t REG_DWORD /d 00000001 \
+    && wine REG ADD "HKEY_LOCAL_MACHINE\SOFTWARE\Blizzard Entertainment\Starcraft" /v intro /t REG_DWORD /d 00000200 \
+    && wine REG ADD "HKEY_LOCAL_MACHINE\SOFTWARE\Blizzard Entertainment\Starcraft" /v introX /t REG_DWORD /d 00000000 \
+    && wine REG ADD "HKEY_LOCAL_MACHINE\SOFTWARE\Blizzard Entertainment\Starcraft" /v unitspeech /t REG_DWORD /d 00000001 \
+    && wine REG ADD "HKEY_LOCAL_MACHINE\SOFTWARE\Blizzard Entertainment\Starcraft" /v unitnoise /t REG_DWORD /d 00000002 \
+    && wine REG ADD "HKEY_LOCAL_MACHINE\SOFTWARE\Blizzard Entertainment\Starcraft" /v bldgnoise /t REG_DWORD /d 00000004 \
+    && wine REG ADD "HKEY_LOCAL_MACHINE\SOFTWARE\Blizzard Entertainment\Starcraft" /v tip /t REG_DWORD /d 00000100 \
+    && wine REG ADD "HKEY_LOCAL_MACHINE\SOFTWARE\Blizzard Entertainment\Starcraft" /v trigtext /t REG_DWORD /d 00000400 \
+    && wine REG ADD "HKEY_LOCAL_MACHINE\SOFTWARE\Blizzard Entertainment\Starcraft" /v StarEdit /t REG_EXPAND_SZ /d "Z:\app\sc\StarEdit.exe" \
+    && wine REG ADD "HKEY_LOCAL_MACHINE\SOFTWARE\Blizzard Entertainment\Starcraft" /v "Recent Maps"  /t REG_EXPAND_SZ /d "" \
+    && wine REG ADD "HKEY_LOCAL_MACHINE\SOFTWARE\Blizzard Entertainment\Starcraft" /v Retail /t REG_EXPAND_SZ /d "y" \
+    && wine REG ADD "HKEY_LOCAL_MACHINE\SOFTWARE\Blizzard Entertainment\Starcraft" /v Brood  /t REG_EXPAND_SZ /d "y" \
+    && wine REG ADD "HKEY_LOCAL_MACHINE\SOFTWARE\Blizzard Entertainment\Starcraft" /v StarCD /t REG_EXPAND_SZ /d "" \
+    && wine REG ADD "HKEY_LOCAL_MACHINE\SOFTWARE\Blizzard Entertainment\Starcraft" /v InstallPath /t REG_EXPAND_SZ /d "Z:\app\sc\\" \
+    && wine REG ADD "HKEY_LOCAL_MACHINE\SOFTWARE\Blizzard Entertainment\Starcraft" /v Program /t REG_EXPAND_SZ /d "Z:\app\sc\StarCraft.exe" \
+    && wine REG ADD "HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Blizzard Entertainment\Starcraft\DelOpt0" /v File0 /t REG_EXPAND_SZ /d "spc" \
+    && wine REG ADD "HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Blizzard Entertainment\Starcraft\DelOpt0" /v File1 /t REG_EXPAND_SZ /d "mpc" \
+    && wine REG ADD "HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Blizzard Entertainment\Starcraft\DelOpt0" /v Path0 /t REG_EXPAND_SZ /d "Z:\app\sc\characters" \
+    && wine REG ADD "HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Blizzard Entertainment\Starcraft\DelOpt0" /v Path1 /t REG_EXPAND_SZ /d "Z:\app\sc\characters" \
+    && sleep 5
+
 WORKDIR $APP_DIR


### PR DESCRIPTION
While doing some debugging, I noticed that a large part of the container startup time was taken applying registry changes. As these are all static, this can be moved to the image build instead to speed up container startup.

On my machine it cuts down the time from running scbw.play to getting the first log message from my bot from about 50 seconds to about 25 seconds.

The first commit contains some changes to just get the images to build, as the Wine downloads on opensuse.org for 18.04 were no longer available. I tried updating to the most recent stable Ubuntu version, but on that version winetricks was unable to install the VC Redist package for some reason. After not getting anywhere fixing that issue, I tried an earlier version and that is working (at least for now).

The second commit tightens up the timings during startup. Especially the change to poll for the StarCraft process being created is needed, as removing the delay from applying the registry updates has made it a bit slower to launch (likely because the OS is still booting). This should be more stable and not need to wait as long.